### PR TITLE
BUGFIX+窗口F7缩放在opengl下失效

### DIFF
--- a/WarcraftHelper/plugin/windowfixer.cpp
+++ b/WarcraftHelper/plugin/windowfixer.cpp
@@ -19,7 +19,10 @@ void ResetWindow(HWND target) {
 DWORD __stdcall Listen(LPVOID lpThreadParameter) {
 	POINT point;        // 鼠标所在位置
 	HWND target;        // 目标窗口句柄
-	HWND org = GetGameInstance()->GetGameWindow();        // 原窗口句柄
+	DWORD origin_pid;
+	DWORD target_pid;
+	HWND org = GetGameInstance()->GetGameWindow(); // 原窗口句柄
+	GetWindowThreadProcessId(org, &origin_pid);
 	while (1)
 	{
 		if (t_closed) {
@@ -29,8 +32,13 @@ DWORD __stdcall Listen(LPVOID lpThreadParameter) {
 		{
 			GetCursorPos(&point);
 			target = WindowFromPoint(point);
-			if (target != NULL && target == org) {
-				ResetWindow(target);
+			if (target != NULL)
+			{
+				GetWindowThreadProcessId(target, &target_pid);
+				if (origin_pid == target_pid)
+				{
+					ResetWindow(target);
+				}
 			}
 		}
 		Sleep(50);


### PR DESCRIPTION
问题描述：
- F7窗口缩放在opengl下失效
- 似乎是opengl导致初始获取句柄有差异，未深入寻找原因

修改内容：
- 将判断逻辑从 __当前窗口句柄对比__ 改为 __句柄对应pid__ 对比

本地环境：
- war3 1.27a
- war3.exe -window -opengl / 偶久本地局域网建图工具2.0